### PR TITLE
Add `todo-card` Component

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -23,6 +23,14 @@
         Users
       </a>
 
+      <a mat-list-item
+        routerLink="/users"
+        routerLinkActive="drawer-list-item-active"
+        (click)="drawer.close()">
+        <mat-icon matListIcon>check</mat-icon>
+        Todos
+      </a>
+
     </mat-nav-list>
   </mat-sidenav>
 

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { LayoutModule } from '@angular/cdk/layout';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatOptionModule } from '@angular/material/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -31,10 +32,12 @@ import { UserCardComponent } from './users/user-card.component';
 import { UserListComponent } from './users/user-list.component';
 import { UserProfileComponent } from './users/user-profile.component';
 import { UserService } from './users/user.service';
+import { TodoCardComponent } from './todo/todo-card/todo-card.component';
 
 const MATERIAL_MODULES: any[] = [
   MatButtonModule,
   MatCardModule,
+  MatCheckboxModule,
   MatDividerModule,
   MatExpansionModule,
   MatFormFieldModule,
@@ -59,6 +62,7 @@ const MATERIAL_MODULES: any[] = [
     UserCardComponent,
     UserProfileComponent,
     AddUserComponent,
+    TodoCardComponent,
   ],
   imports: [
     BrowserModule,

--- a/client/src/app/todo/todo-card/todo-card.component.html
+++ b/client/src/app/todo/todo-card/todo-card.component.html
@@ -1,0 +1,11 @@
+<mat-card>
+  <mat-checkbox class="example-margin">
+    <mat-card-header>
+        <mat-card-title>Category</mat-card-title>
+        <mat-card-subtitle>Name</mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+        This is the description of the todo item
+    </mat-card-content>
+  </mat-checkbox>
+</mat-card>

--- a/client/src/app/todo/todo-card/todo-card.component.html
+++ b/client/src/app/todo/todo-card/todo-card.component.html
@@ -1,11 +1,11 @@
-<mat-card>
-  <mat-checkbox class="example-margin">
+<mat-card *ngIf="this.todo">
+  <mat-checkbox class="example-margin" [(ngModel)]="this.todo.status">
     <mat-card-header>
-        <mat-card-title>Category</mat-card-title>
-        <mat-card-subtitle>Name</mat-card-subtitle>
+        <mat-card-title>{{ this.todo.category }}</mat-card-title>
+        <mat-card-subtitle>{{ this.todo.owner }}</mat-card-subtitle>
     </mat-card-header>
     <mat-card-content>
-        This is the description of the todo item
+        {{ this.todo.body }}
     </mat-card-content>
   </mat-checkbox>
 </mat-card>

--- a/client/src/app/todo/todo-card/todo-card.component.html
+++ b/client/src/app/todo/todo-card/todo-card.component.html
@@ -1,10 +1,10 @@
-<mat-card *ngIf="this.todo">
-  <mat-checkbox class="example-margin" [(ngModel)]="this.todo.status">
-    <mat-card-header>
-        <mat-card-title>{{ this.todo.category }}</mat-card-title>
-        <mat-card-subtitle>{{ this.todo.owner }}</mat-card-subtitle>
+<mat-card class="todo-card" *ngIf="this.todo">
+  <mat-checkbox class="example-margin" [(ngModel)]="this.todo.status" class="todo-card-check">
+    <mat-card-header class="todo-card-header">
+        <mat-card-title class="todo-card-category">{{ this.todo.category }}</mat-card-title>
+        <mat-card-subtitle class="todo-card-owner">{{ this.todo.owner }}</mat-card-subtitle>
     </mat-card-header>
-    <mat-card-content>
+    <mat-card-content class="todo-card-content todo-card-body">
         {{ this.todo.body }}
     </mat-card-content>
   </mat-checkbox>

--- a/client/src/app/todo/todo-card/todo-card.component.scss
+++ b/client/src/app/todo/todo-card/todo-card.component.scss
@@ -1,0 +1,3 @@
+.todo-card {
+  width: 50%;
+}

--- a/client/src/app/todo/todo-card/todo-card.component.spec.ts
+++ b/client/src/app/todo/todo-card/todo-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TodoCardComponent } from './todo-card.component';
+
+describe('TodoCardComponent', () => {
+  let component: TodoCardComponent;
+  let fixture: ComponentFixture<TodoCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TodoCardComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TodoCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/todo/todo-card/todo-card.component.ts
+++ b/client/src/app/todo/todo-card/todo-card.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-todo-card',
+  templateUrl: './todo-card.component.html',
+  styleUrls: ['./todo-card.component.scss']
+})
+export class TodoCardComponent {
+
+}

--- a/client/src/app/todo/todo-card/todo-card.component.ts
+++ b/client/src/app/todo/todo-card/todo-card.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { Todo } from '../todo';
 
 @Component({
   selector: 'app-todo-card',
@@ -6,5 +7,8 @@ import { Component } from '@angular/core';
   styleUrls: ['./todo-card.component.scss']
 })
 export class TodoCardComponent {
+  @Input() todo: Todo;
 
+  constructor() {
+  }
 }

--- a/client/src/app/todo/todo.ts
+++ b/client/src/app/todo/todo.ts
@@ -1,0 +1,7 @@
+export interface Todo {
+  _id: string;
+  owner: string;
+  status: boolean;
+  body: string;
+  category: string;
+}


### PR DESCRIPTION
Add a `todo-card` component which can be used to properly render a `Todo` object. The component uses a checkbox to display the current status of a todo, and shows the name, category, and body in text within its body. 